### PR TITLE
Migración de SQL Server a PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Personal files
+planing.md

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -68,7 +68,7 @@ builder.Services.AddSingleton<IUriService>(provider =>
 
 builder.Services.AddDbContext<FakeRubikStoreContext>(options =>
 {
-    options.UseSqlServer(builder.Configuration.GetConnectionString("Prod")).LogTo(Console.WriteLine, LogLevel.Information);
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DEV")).LogTo(Console.WriteLine, LogLevel.Information);
 });
 
 builder.Services.AddAuthentication(opt =>

--- a/Aplication/Aplication.csproj
+++ b/Aplication/Aplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Infraestructure/Data/Config/OrderConfig.cs
+++ b/Infraestructure/Data/Config/OrderConfig.cs
@@ -10,7 +10,7 @@ namespace Infraestructure.Data.Config
         {
             entity.HasKey(x => x.Id);
             entity.ToTable("Ordenes");
-            entity.Property(e => e.Date).HasColumnType("datetime").HasColumnName("Fecha");
+            entity.Property(e => e.Date).HasColumnType("timestamp").HasColumnName("Fecha");
             entity.Property(e => e.FinalPrice).HasColumnName("PrecioFinal");
             entity.Property(e => e.IdDelivery).HasColumnName("IdEnvio");
             entity.Property(e => e.NumberCard).HasColumnName("numerotarjeta");

--- a/Infraestructure/Infraestructure.csproj
+++ b/Infraestructure/Infraestructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -14,8 +14,8 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Infraestructure/Infraestructure.csproj
+++ b/Infraestructure/Infraestructure.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Infraestructure/Migrations/20260405221432_InitialPostgres.Designer.cs
+++ b/Infraestructure/Migrations/20260405221432_InitialPostgres.Designer.cs
@@ -3,41 +3,41 @@ using System;
 using Infraestructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
 namespace Infraestructure.Migrations
 {
     [DbContext(typeof(FakeRubikStoreContext))]
-    [Migration("20240304162123_UpdateRelations")]
-    partial class UpdateRelations
+    [Migration("20260405221432_InitialPostgres")]
+    partial class InitialPostgres
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Aplication.Entities.Category", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -49,23 +49,23 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .HasMaxLength(100)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(100)")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("Codigo");
 
                     b.Property<int>("IdState")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdEstado");
 
                     b.Property<int>("IdUser")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdUsuario");
 
                     b.HasKey("Id");
@@ -81,24 +81,29 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("datetime")
+                        .HasColumnType("timestamp")
                         .HasColumnName("Fecha");
 
                     b.Property<double>("FinalPrice")
-                        .HasColumnType("float")
+                        .HasColumnType("double precision")
                         .HasColumnName("PrecioFinal");
 
                     b.Property<int>("IdDelivery")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdEnvio");
 
                     b.Property<int>("IdUser")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    b.Property<string>("NumberCard")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("numerotarjeta");
 
                     b.HasKey("Id");
 
@@ -111,33 +116,25 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.OrdersProducts", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("IdOrder")
-                        .HasColumnType("int")
-                        .HasColumnName("IdOrden");
-
-                    b.Property<int?>("IdProduct")
-                        .HasColumnType("int")
+                    b.Property<int>("IdProduct")
+                        .HasColumnType("integer")
                         .HasColumnName("IdProducto");
 
+                    b.Property<int>("IdOrder")
+                        .HasColumnType("integer")
+                        .HasColumnName("IdOrden");
+
                     b.Property<double>("Price")
-                        .HasColumnType("float")
+                        .HasColumnType("double precision")
                         .HasColumnName("Precio");
 
                     b.Property<int>("ProductsNumber")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("Cantidad");
 
-                    b.HasKey("Id");
+                    b.HasKey("IdProduct", "IdOrder");
 
                     b.HasIndex("IdOrder");
-
-                    b.HasIndex("IdProduct");
 
                     b.ToTable("Productos_Ordenes", (string)null);
                 });
@@ -146,60 +143,55 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasMaxLength(200)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(200)")
+                        .HasColumnType("text")
                         .HasColumnName("Descripcion");
 
                     b.Property<string>("Image")
-                        .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("text")
                         .HasColumnName("Imagen");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("NombreProducto");
 
                     b.Property<double>("Price")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision")
+                        .HasColumnName("Precio");
 
                     b.Property<int>("Stock")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Thumbnail")
                         .IsRequired()
-                        .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("text")
                         .HasColumnName("Miniatura");
 
                     b.HasKey("Id");
 
-                    b.ToTable("Products");
+                    b.ToTable("Productos", (string)null);
                 });
 
             modelBuilder.Entity("Aplication.Entities.ProductCategory", b =>
                 {
                     b.Property<int>("IdProduct")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdProducto");
 
                     b.Property<int>("IdCategory")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdCategoria");
-
-                    b.Property<int>("Id")
-                        .HasColumnType("int");
 
                     b.HasKey("IdProduct", "IdCategory");
 
@@ -211,19 +203,19 @@ namespace Infraestructure.Migrations
             modelBuilder.Entity("Aplication.Entities.ProductsProviders", b =>
                 {
                     b.Property<int>("IdProduct")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProvider")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Id")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProductosNavigationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProveedoresNavigationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("IdProduct", "IdProvider");
 
@@ -238,21 +230,21 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Phone")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -261,26 +253,25 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.Review", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                    b.Property<int>("ProductId")
+                        .HasColumnType("integer")
+                        .HasColumnName("IdProducto");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    b.Property<int>("UserId")
+                        .HasColumnType("integer")
+                        .HasColumnName("UsuarioId");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("text")
                         .HasColumnName("Descripcion");
 
-                    b.Property<int>("ProductId")
-                        .HasColumnType("int");
-
                     b.Property<int>("Rate")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("rate");
 
-                    b.HasKey("Id");
+                    b.HasKey("ProductId", "UserId");
 
-                    b.HasIndex("ProductId");
+                    b.HasIndex("UserId");
 
                     b.ToTable("Reviews", (string)null);
                 });
@@ -289,16 +280,16 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdRol");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(20)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(20)")
+                        .HasColumnType("character varying(20)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -310,15 +301,15 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -330,47 +321,47 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)");
+                        .HasColumnType("character varying(50)");
 
                     b.Property<int>("IdAddress")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdDireccion");
 
                     b.Property<int>("IdRole")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdRol");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.Property<string>("Password")
                         .IsRequired()
                         .HasMaxLength(150)
-                        .HasColumnType("nvarchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("Contrasena");
 
                     b.Property<string>("Phone")
                         .IsRequired()
                         .HasMaxLength(30)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(30)")
+                        .HasColumnType("character varying(30)")
                         .HasColumnName("Telefono");
 
                     b.Property<string>("SecondName")
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Apellido");
 
                     b.HasKey("Id");
@@ -387,38 +378,38 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Address")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("Direccion");
 
                     b.Property<string>("City")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("ciudad");
 
                     b.Property<string>("Country")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("pais");
 
                     b.Property<string>("Description")
                         .HasMaxLength(100)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(100)")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("descripcion");
 
                     b.Property<string>("State")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("estado");
 
                     b.HasKey("Id");
@@ -447,21 +438,22 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.Order", b =>
                 {
-                    b.HasOne("Aplication.Entities.Delivery", "DeliveryNav")
+                    b.HasOne("Aplication.Entities.Delivery", "DeliveryInfo")
                         .WithMany("Orders")
                         .HasForeignKey("IdDelivery")
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
                         .HasConstraintName("FK_Ordenes_Envios");
 
-                    b.HasOne("Aplication.Entities.User", "UserNav")
+                    b.HasOne("Aplication.Entities.User", "UserInfo")
                         .WithMany("Orders")
                         .HasForeignKey("IdUser")
                         .IsRequired()
                         .HasConstraintName("FK_Ordenes_Usuarios");
 
-                    b.Navigation("DeliveryNav");
+                    b.Navigation("DeliveryInfo");
 
-                    b.Navigation("UserNav");
+                    b.Navigation("UserInfo");
                 });
 
             modelBuilder.Entity("Aplication.Entities.OrdersProducts", b =>
@@ -472,14 +464,16 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Productos_Ordenes_Ordenes");
 
-                    b.HasOne("Aplication.Entities.Product", "ProductNav")
+                    b.HasOne("Aplication.Entities.Product", "ProductInfo")
                         .WithMany("OrderProducts")
                         .HasForeignKey("IdProduct")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
                         .HasConstraintName("FK_Productos_Ordenes_Productos");
 
                     b.Navigation("OrderNav");
 
-                    b.Navigation("ProductNav");
+                    b.Navigation("ProductInfo");
                 });
 
             modelBuilder.Entity("Aplication.Entities.ProductCategory", b =>
@@ -529,12 +523,21 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Review_Productos");
 
+                    b.HasOne("Aplication.Entities.User", "Usuario")
+                        .WithMany("Reviews")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("FK_Reviews_Usuarios");
+
                     b.Navigation("Product");
+
+                    b.Navigation("Usuario");
                 });
 
             modelBuilder.Entity("Aplication.Entities.User", b =>
                 {
-                    b.HasOne("Aplication.Entities.UserDirection", "UserDirectionNav")
+                    b.HasOne("Aplication.Entities.UserDirection", "AdressInfo")
                         .WithOne("User")
                         .HasForeignKey("Aplication.Entities.User", "IdAddress")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -547,9 +550,9 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Usuarios_Rol");
 
-                    b.Navigation("RoleNav");
+                    b.Navigation("AdressInfo");
 
-                    b.Navigation("UserDirectionNav");
+                    b.Navigation("RoleNav");
                 });
 
             modelBuilder.Entity("Aplication.Entities.Category", b =>
@@ -598,6 +601,8 @@ namespace Infraestructure.Migrations
                     b.Navigation("Deliveries");
 
                     b.Navigation("Orders");
+
+                    b.Navigation("Reviews");
                 });
 
             modelBuilder.Entity("Aplication.Entities.UserDirection", b =>

--- a/Infraestructure/Migrations/20260405221432_InitialPostgres.cs
+++ b/Infraestructure/Migrations/20260405221432_InitialPostgres.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
 namespace Infraestructure.Migrations
 {
     /// <inheritdoc />
-    public partial class UpdateRelations : Migration
+    public partial class InitialPostgres : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -15,9 +16,9 @@ namespace Infraestructure.Migrations
                 name: "Categorias",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Nombre = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Nombre = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -28,13 +29,13 @@ namespace Infraestructure.Migrations
                 name: "Direccion",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Direccion = table.Column<string>(type: "varchar(150)", unicode: false, maxLength: 150, nullable: true),
-                    ciudad = table.Column<string>(type: "varchar(150)", unicode: false, maxLength: 150, nullable: true),
-                    estado = table.Column<string>(type: "varchar(150)", unicode: false, maxLength: 150, nullable: true),
-                    pais = table.Column<string>(type: "varchar(150)", unicode: false, maxLength: 150, nullable: true),
-                    descripcion = table.Column<string>(type: "varchar(100)", unicode: false, maxLength: 100, nullable: true)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Direccion = table.Column<string>(type: "character varying(150)", unicode: false, maxLength: 150, nullable: true),
+                    ciudad = table.Column<string>(type: "character varying(150)", unicode: false, maxLength: 150, nullable: true),
+                    estado = table.Column<string>(type: "character varying(150)", unicode: false, maxLength: 150, nullable: true),
+                    pais = table.Column<string>(type: "character varying(150)", unicode: false, maxLength: 150, nullable: true),
+                    descripcion = table.Column<string>(type: "character varying(100)", unicode: false, maxLength: 100, nullable: true)
                 },
                 constraints: table =>
                 {
@@ -45,9 +46,9 @@ namespace Infraestructure.Migrations
                 name: "Estado",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Nombre = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Nombre = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -55,32 +56,32 @@ namespace Infraestructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "Products",
+                name: "Productos",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    NombreProducto = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: false),
-                    Price = table.Column<double>(type: "float", nullable: false),
-                    Stock = table.Column<int>(type: "int", nullable: false),
-                    Imagen = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: true),
-                    Descripcion = table.Column<string>(type: "varchar(200)", unicode: false, maxLength: 200, nullable: false),
-                    Miniatura = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    NombreProducto = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: false),
+                    Precio = table.Column<double>(type: "double precision", nullable: false),
+                    Stock = table.Column<int>(type: "integer", nullable: false),
+                    Imagen = table.Column<string>(type: "text", unicode: false, nullable: true),
+                    Descripcion = table.Column<string>(type: "text", unicode: false, nullable: false),
+                    Miniatura = table.Column<string>(type: "text", unicode: false, nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_Products", x => x.Id);
+                    table.PrimaryKey("PK_Productos", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
                 name: "Providers",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    Phone = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    Email = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Phone = table.Column<string>(type: "text", nullable: false),
+                    Email = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -91,9 +92,9 @@ namespace Infraestructure.Migrations
                 name: "Rol",
                 columns: table => new
                 {
-                    IdRol = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Nombre = table.Column<string>(type: "varchar(20)", unicode: false, maxLength: 20, nullable: false)
+                    IdRol = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Nombre = table.Column<string>(type: "character varying(20)", unicode: false, maxLength: 20, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -104,9 +105,8 @@ namespace Infraestructure.Migrations
                 name: "Categorias_Productos",
                 columns: table => new
                 {
-                    IdCategoria = table.Column<int>(type: "int", nullable: false),
-                    IdProducto = table.Column<int>(type: "int", nullable: false),
-                    Id = table.Column<int>(type: "int", nullable: false)
+                    IdCategoria = table.Column<int>(type: "integer", nullable: false),
+                    IdProducto = table.Column<int>(type: "integer", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -119,48 +119,27 @@ namespace Infraestructure.Migrations
                     table.ForeignKey(
                         name: "FK_Categorias_Productos_Productos",
                         column: x => x.IdProducto,
-                        principalTable: "Products",
+                        principalTable: "Productos",
                         principalColumn: "Id");
-                });
-
-            migrationBuilder.CreateTable(
-                name: "Reviews",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    ProductId = table.Column<int>(type: "int", nullable: false),
-                    Descripcion = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    rate = table.Column<int>(type: "int", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Reviews", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Review_Productos",
-                        column: x => x.ProductId,
-                        principalTable: "Products",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
                 name: "ProductsProviders",
                 columns: table => new
                 {
-                    IdProvider = table.Column<int>(type: "int", nullable: false),
-                    IdProduct = table.Column<int>(type: "int", nullable: false),
-                    IdProductosNavigationId = table.Column<int>(type: "int", nullable: false),
-                    IdProveedoresNavigationId = table.Column<int>(type: "int", nullable: false),
-                    Id = table.Column<int>(type: "int", nullable: false)
+                    IdProvider = table.Column<int>(type: "integer", nullable: false),
+                    IdProduct = table.Column<int>(type: "integer", nullable: false),
+                    IdProductosNavigationId = table.Column<int>(type: "integer", nullable: false),
+                    IdProveedoresNavigationId = table.Column<int>(type: "integer", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_ProductsProviders", x => new { x.IdProduct, x.IdProvider });
                     table.ForeignKey(
-                        name: "FK_ProductsProviders_Products_IdProductosNavigationId",
+                        name: "FK_ProductsProviders_Productos_IdProductosNavigationId",
                         column: x => x.IdProductosNavigationId,
-                        principalTable: "Products",
+                        principalTable: "Productos",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
@@ -175,15 +154,15 @@ namespace Infraestructure.Migrations
                 name: "Usuarios",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    IdRol = table.Column<int>(type: "int", nullable: false),
-                    IdDireccion = table.Column<int>(type: "int", nullable: false),
-                    Nombre = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: true),
-                    Apellido = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: true),
-                    Email = table.Column<string>(type: "varchar(50)", unicode: false, maxLength: 50, nullable: false),
-                    Contrasena = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
-                    Telefono = table.Column<string>(type: "varchar(30)", unicode: false, maxLength: 30, nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    IdRol = table.Column<int>(type: "integer", nullable: false),
+                    IdDireccion = table.Column<int>(type: "integer", nullable: false),
+                    Nombre = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: true),
+                    Apellido = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: true),
+                    Email = table.Column<string>(type: "character varying(50)", unicode: false, maxLength: 50, nullable: false),
+                    Contrasena = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    Telefono = table.Column<string>(type: "character varying(30)", unicode: false, maxLength: 30, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -205,11 +184,11 @@ namespace Infraestructure.Migrations
                 name: "Envios",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    IdEstado = table.Column<int>(type: "int", nullable: false),
-                    IdUsuario = table.Column<int>(type: "int", nullable: false),
-                    Codigo = table.Column<string>(type: "varchar(100)", unicode: false, maxLength: 100, nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    IdEstado = table.Column<int>(type: "integer", nullable: false),
+                    IdUsuario = table.Column<int>(type: "integer", nullable: false),
+                    Codigo = table.Column<string>(type: "character varying(100)", unicode: false, maxLength: 100, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -227,15 +206,42 @@ namespace Infraestructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "Reviews",
+                columns: table => new
+                {
+                    IdProducto = table.Column<int>(type: "integer", nullable: false),
+                    UsuarioId = table.Column<int>(type: "integer", nullable: false),
+                    Descripcion = table.Column<string>(type: "text", nullable: true),
+                    rate = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Reviews", x => new { x.IdProducto, x.UsuarioId });
+                    table.ForeignKey(
+                        name: "FK_Review_Productos",
+                        column: x => x.IdProducto,
+                        principalTable: "Productos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Reviews_Usuarios",
+                        column: x => x.UsuarioId,
+                        principalTable: "Usuarios",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Ordenes",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    IdUser = table.Column<int>(type: "int", nullable: false),
-                    IdEnvio = table.Column<int>(type: "int", nullable: false),
-                    Fecha = table.Column<DateTime>(type: "datetime", nullable: false),
-                    PrecioFinal = table.Column<double>(type: "float", nullable: false)
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    IdUser = table.Column<int>(type: "integer", nullable: false),
+                    IdEnvio = table.Column<int>(type: "integer", nullable: false),
+                    Fecha = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    PrecioFinal = table.Column<double>(type: "double precision", nullable: false),
+                    numerotarjeta = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -244,7 +250,8 @@ namespace Infraestructure.Migrations
                         name: "FK_Ordenes_Envios",
                         column: x => x.IdEnvio,
                         principalTable: "Envios",
-                        principalColumn: "Id");
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_Ordenes_Usuarios",
                         column: x => x.IdUser,
@@ -256,16 +263,14 @@ namespace Infraestructure.Migrations
                 name: "Productos_Ordenes",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    IdProducto = table.Column<int>(type: "int", nullable: true),
-                    IdOrden = table.Column<int>(type: "int", nullable: false),
-                    Cantidad = table.Column<int>(type: "int", nullable: false),
-                    Precio = table.Column<double>(type: "float", nullable: false)
+                    IdProducto = table.Column<int>(type: "integer", nullable: false),
+                    IdOrden = table.Column<int>(type: "integer", nullable: false),
+                    Cantidad = table.Column<int>(type: "integer", nullable: false),
+                    Precio = table.Column<double>(type: "double precision", nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_Productos_Ordenes", x => x.Id);
+                    table.PrimaryKey("PK_Productos_Ordenes", x => new { x.IdProducto, x.IdOrden });
                     table.ForeignKey(
                         name: "FK_Productos_Ordenes_Ordenes",
                         column: x => x.IdOrden,
@@ -274,8 +279,9 @@ namespace Infraestructure.Migrations
                     table.ForeignKey(
                         name: "FK_Productos_Ordenes_Productos",
                         column: x => x.IdProducto,
-                        principalTable: "Products",
-                        principalColumn: "Id");
+                        principalTable: "Productos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(
@@ -309,11 +315,6 @@ namespace Infraestructure.Migrations
                 column: "IdOrden");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Productos_Ordenes_IdProducto",
-                table: "Productos_Ordenes",
-                column: "IdProducto");
-
-            migrationBuilder.CreateIndex(
                 name: "IX_ProductsProviders_IdProductosNavigationId",
                 table: "ProductsProviders",
                 column: "IdProductosNavigationId");
@@ -324,9 +325,9 @@ namespace Infraestructure.Migrations
                 column: "IdProveedoresNavigationId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Reviews_ProductId",
+                name: "IX_Reviews_UsuarioId",
                 table: "Reviews",
-                column: "ProductId");
+                column: "UsuarioId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Usuarios_IdDireccion",
@@ -365,7 +366,7 @@ namespace Infraestructure.Migrations
                 name: "Providers");
 
             migrationBuilder.DropTable(
-                name: "Products");
+                name: "Productos");
 
             migrationBuilder.DropTable(
                 name: "Envios");

--- a/Infraestructure/Migrations/FakeRubikStoreContextModelSnapshot.cs
+++ b/Infraestructure/Migrations/FakeRubikStoreContextModelSnapshot.cs
@@ -3,8 +3,8 @@ using System;
 using Infraestructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
@@ -17,24 +17,24 @@ namespace Infraestructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Aplication.Entities.Category", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -46,23 +46,23 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Code")
                         .IsRequired()
                         .HasMaxLength(100)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(100)")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("Codigo");
 
                     b.Property<int>("IdState")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdEstado");
 
                     b.Property<int>("IdUser")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdUsuario");
 
                     b.HasKey("Id");
@@ -78,24 +78,29 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("datetime")
+                        .HasColumnType("timestamp")
                         .HasColumnName("Fecha");
 
                     b.Property<double>("FinalPrice")
-                        .HasColumnType("float")
+                        .HasColumnType("double precision")
                         .HasColumnName("PrecioFinal");
 
                     b.Property<int>("IdDelivery")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdEnvio");
 
                     b.Property<int>("IdUser")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    b.Property<string>("NumberCard")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("numerotarjeta");
 
                     b.HasKey("Id");
 
@@ -108,33 +113,25 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.OrdersProducts", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("IdOrder")
-                        .HasColumnType("int")
-                        .HasColumnName("IdOrden");
-
-                    b.Property<int?>("IdProduct")
-                        .HasColumnType("int")
+                    b.Property<int>("IdProduct")
+                        .HasColumnType("integer")
                         .HasColumnName("IdProducto");
 
+                    b.Property<int>("IdOrder")
+                        .HasColumnType("integer")
+                        .HasColumnName("IdOrden");
+
                     b.Property<double>("Price")
-                        .HasColumnType("float")
+                        .HasColumnType("double precision")
                         .HasColumnName("Precio");
 
                     b.Property<int>("ProductsNumber")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("Cantidad");
 
-                    b.HasKey("Id");
+                    b.HasKey("IdProduct", "IdOrder");
 
                     b.HasIndex("IdOrder");
-
-                    b.HasIndex("IdProduct");
 
                     b.ToTable("Productos_Ordenes", (string)null);
                 });
@@ -143,60 +140,55 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasMaxLength(200)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(200)")
+                        .HasColumnType("text")
                         .HasColumnName("Descripcion");
 
                     b.Property<string>("Image")
-                        .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("text")
                         .HasColumnName("Imagen");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("NombreProducto");
 
                     b.Property<double>("Price")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision")
+                        .HasColumnName("Precio");
 
                     b.Property<int>("Stock")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Thumbnail")
                         .IsRequired()
-                        .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("text")
                         .HasColumnName("Miniatura");
 
                     b.HasKey("Id");
 
-                    b.ToTable("Products");
+                    b.ToTable("Productos", (string)null);
                 });
 
             modelBuilder.Entity("Aplication.Entities.ProductCategory", b =>
                 {
                     b.Property<int>("IdProduct")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdProducto");
 
                     b.Property<int>("IdCategory")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdCategoria");
-
-                    b.Property<int>("Id")
-                        .HasColumnType("int");
 
                     b.HasKey("IdProduct", "IdCategory");
 
@@ -208,19 +200,19 @@ namespace Infraestructure.Migrations
             modelBuilder.Entity("Aplication.Entities.ProductsProviders", b =>
                 {
                     b.Property<int>("IdProduct")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProvider")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Id")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProductosNavigationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("IdProveedoresNavigationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("IdProduct", "IdProvider");
 
@@ -235,21 +227,21 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Phone")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -258,26 +250,25 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.Review", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                    b.Property<int>("ProductId")
+                        .HasColumnType("integer")
+                        .HasColumnName("IdProducto");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    b.Property<int>("UserId")
+                        .HasColumnType("integer")
+                        .HasColumnName("UsuarioId");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("text")
                         .HasColumnName("Descripcion");
 
-                    b.Property<int>("ProductId")
-                        .HasColumnType("int");
-
                     b.Property<int>("Rate")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("rate");
 
-                    b.HasKey("Id");
+                    b.HasKey("ProductId", "UserId");
 
-                    b.HasIndex("ProductId");
+                    b.HasIndex("UserId");
 
                     b.ToTable("Reviews", (string)null);
                 });
@@ -286,16 +277,16 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdRol");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(20)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(20)")
+                        .HasColumnType("character varying(20)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -307,15 +298,15 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.HasKey("Id");
@@ -327,47 +318,47 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)");
+                        .HasColumnType("character varying(50)");
 
                     b.Property<int>("IdAddress")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdDireccion");
 
                     b.Property<int>("IdRole")
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasColumnName("IdRol");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Nombre");
 
                     b.Property<string>("Password")
                         .IsRequired()
                         .HasMaxLength(150)
-                        .HasColumnType("nvarchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("Contrasena");
 
                     b.Property<string>("Phone")
                         .IsRequired()
                         .HasMaxLength(30)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(30)")
+                        .HasColumnType("character varying(30)")
                         .HasColumnName("Telefono");
 
                     b.Property<string>("SecondName")
                         .HasMaxLength(50)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(50)")
+                        .HasColumnType("character varying(50)")
                         .HasColumnName("Apellido");
 
                     b.HasKey("Id");
@@ -384,38 +375,38 @@ namespace Infraestructure.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Address")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("Direccion");
 
                     b.Property<string>("City")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("ciudad");
 
                     b.Property<string>("Country")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("pais");
 
                     b.Property<string>("Description")
                         .HasMaxLength(100)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(100)")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("descripcion");
 
                     b.Property<string>("State")
                         .HasMaxLength(150)
                         .IsUnicode(false)
-                        .HasColumnType("varchar(150)")
+                        .HasColumnType("character varying(150)")
                         .HasColumnName("estado");
 
                     b.HasKey("Id");
@@ -444,21 +435,22 @@ namespace Infraestructure.Migrations
 
             modelBuilder.Entity("Aplication.Entities.Order", b =>
                 {
-                    b.HasOne("Aplication.Entities.Delivery", "DeliveryNav")
+                    b.HasOne("Aplication.Entities.Delivery", "DeliveryInfo")
                         .WithMany("Orders")
                         .HasForeignKey("IdDelivery")
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
                         .HasConstraintName("FK_Ordenes_Envios");
 
-                    b.HasOne("Aplication.Entities.User", "UserNav")
+                    b.HasOne("Aplication.Entities.User", "UserInfo")
                         .WithMany("Orders")
                         .HasForeignKey("IdUser")
                         .IsRequired()
                         .HasConstraintName("FK_Ordenes_Usuarios");
 
-                    b.Navigation("DeliveryNav");
+                    b.Navigation("DeliveryInfo");
 
-                    b.Navigation("UserNav");
+                    b.Navigation("UserInfo");
                 });
 
             modelBuilder.Entity("Aplication.Entities.OrdersProducts", b =>
@@ -469,14 +461,16 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Productos_Ordenes_Ordenes");
 
-                    b.HasOne("Aplication.Entities.Product", "ProductNav")
+                    b.HasOne("Aplication.Entities.Product", "ProductInfo")
                         .WithMany("OrderProducts")
                         .HasForeignKey("IdProduct")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
                         .HasConstraintName("FK_Productos_Ordenes_Productos");
 
                     b.Navigation("OrderNav");
 
-                    b.Navigation("ProductNav");
+                    b.Navigation("ProductInfo");
                 });
 
             modelBuilder.Entity("Aplication.Entities.ProductCategory", b =>
@@ -526,12 +520,21 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Review_Productos");
 
+                    b.HasOne("Aplication.Entities.User", "Usuario")
+                        .WithMany("Reviews")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired()
+                        .HasConstraintName("FK_Reviews_Usuarios");
+
                     b.Navigation("Product");
+
+                    b.Navigation("Usuario");
                 });
 
             modelBuilder.Entity("Aplication.Entities.User", b =>
                 {
-                    b.HasOne("Aplication.Entities.UserDirection", "UserDirectionNav")
+                    b.HasOne("Aplication.Entities.UserDirection", "AdressInfo")
                         .WithOne("User")
                         .HasForeignKey("Aplication.Entities.User", "IdAddress")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -544,9 +547,9 @@ namespace Infraestructure.Migrations
                         .IsRequired()
                         .HasConstraintName("FK_Usuarios_Rol");
 
-                    b.Navigation("RoleNav");
+                    b.Navigation("AdressInfo");
 
-                    b.Navigation("UserDirectionNav");
+                    b.Navigation("RoleNav");
                 });
 
             modelBuilder.Entity("Aplication.Entities.Category", b =>
@@ -595,6 +598,8 @@ namespace Infraestructure.Migrations
                     b.Navigation("Deliveries");
 
                     b.Navigation("Orders");
+
+                    b.Navigation("Reviews");
                 });
 
             modelBuilder.Entity("Aplication.Entities.UserDirection", b =>


### PR DESCRIPTION
## Descripción
Se realizó la migración de la base de datos de SQL Server a PostgreSQL para alinear la infraestructura con el nuevo motor de persistencia.
Este cambio incluye la actualización de la configuración de conexión, adaptación de consultas y ajustes necesarios en la capa de acceso a datos para asegurar compatibilidad con PostgreSQL.

## Principales cambios
Reemplazo de la configuración de SQL Server por PostgreSQL.
Ajuste de la cadena de conexión y variables de entorno.
Adaptación de consultas y mapeos afectados por diferencias entre motores.
Validación del funcionamiento de los endpoints con la nueva base de datos.
## Validacion
Se verificó la conexión contra PostgreSQL.
Se revisaron los flujos principales de lectura y escritura.
Se confirmaron los endpoints críticos después de la migración.